### PR TITLE
feat: add claude-inspired dark theme

### DIFF
--- a/claude-theme.css
+++ b/claude-theme.css
@@ -1,0 +1,67 @@
+/* Claude.ai inspired dark theme */
+
+/* Color palette derived from the live claude.ai interface */
+:root {
+  --claude-bg: #0d0d0f;
+  --claude-surface: #16161a;
+  --claude-card: #1e1e22;
+  --claude-border: #2a2b31;
+  --claude-text: #e5e5e7;
+  --claude-muted: #a1a1aa;
+  --claude-accent: #8e61ff;
+}
+
+body.claude {
+  background-color: var(--claude-bg);
+  color: var(--claude-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+body.claude a {
+  color: var(--claude-accent);
+}
+
+body.claude .header,
+body.claude .card,
+body.claude .feature-card,
+body.claude .cta-section {
+  background: var(--claude-card);
+  color: var(--claude-text);
+  border: 1px solid var(--claude-border);
+  box-shadow: none;
+}
+
+body.claude .feature-card {
+  border-left: 4px solid var(--claude-accent);
+}
+
+body.claude .cta-section {
+  background: linear-gradient(135deg, #2f235a 0%, #472a8d 100%);
+  border: none;
+}
+
+body.claude .cta-button {
+  background-color: var(--claude-accent);
+  color: var(--claude-bg);
+}
+
+body.claude .cta-button.secondary {
+  background: transparent;
+  border: 1px solid var(--claude-border);
+  color: var(--claude-text);
+}
+
+body.claude .status-badge {
+  background: var(--claude-accent);
+  color: var(--claude-bg);
+}
+
+body.claude .formula-old {
+  background: rgba(239, 68, 68, 0.15);
+  border-left: 3px solid #ef4444;
+}
+
+body.claude .formula-new {
+  background: rgba(34, 197, 94, 0.15);
+  border-left: 3px solid #22c55e;
+}

--- a/index.html
+++ b/index.html
@@ -198,8 +198,9 @@
             transform: translateY(-2px);
         }
     </style>
+    <link rel="stylesheet" href="claude-theme.css">
 </head>
-<body>
+<body class="claude">
     <div class="container">
         <!-- Header -->
         <div class="header">


### PR DESCRIPTION
## Summary
- add claude-theme.css with dark palette resembling claude.ai
- link theme in landing page and apply claude class
- refine palette and extend theme to CTA section, badges, and formulas

## Testing
- `python3 -m http.server 8080 &`
- `curl -I http://localhost:8080/index.html`
- `curl -I http://localhost:8080/claude-theme.css`


------
https://chatgpt.com/codex/tasks/task_e_68aa915d82ac832ca41448524944eb1f