### PR TITLE
feat: add dark theme and fonts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <link rel="stylesheet" href="styles/chatgpt-dark.css">
     
     <!-- Custom Styles -->
     <style>

--- a/src/styles/chatgpt-dark.css
+++ b/src/styles/chatgpt-dark.css
@@ -1,0 +1,31 @@
+/* ChatGPT-style dark theme with Claude fonts */
+@import url('https://fonts.cdnfonts.com/css/tiempos');
+@import url('https://fonts.cdnfonts.com/css/styrenea');
+@import url('https://fonts.cdnfonts.com/css/copernicus');
+
+:root {
+  --bg-primary: #343541;
+  --bg-secondary: #444654;
+  --text-primary: #ececf1;
+  --accent: #10a37f;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: 'Tiempos', 'Styrene A', 'Copernicus', sans-serif;
+}
+
+button, input, select, textarea {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid #565869;
+}
+
+button:hover {
+  background-color: #565869;
+}
+
+a {
+  color: var(--accent);
+}


### PR DESCRIPTION
## Summary
- add ChatGPT-style dark theme stylesheet with Claude fonts
- load new theme in modular index.html

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aa954e86bc832c82269c7cbc617875